### PR TITLE
Self aware tiles

### DIFF
--- a/src/Board.py
+++ b/src/Board.py
@@ -1,6 +1,6 @@
 # import random
 # import math
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Set
 
 from Cult import Cult
 from errors import InvalidActionError
@@ -122,7 +122,7 @@ class Board:
                 )
         return all_tiles
 
-    def filter_terrain(self, tiles, terrain_filter=None) -> set:
+    def filter_terrain(self, tiles: Set[Tile], terrain_filter=None) -> set:
         filtered_tiles = set()
         for tile in tiles:
             if tile.terrain == terrain_filter:
@@ -130,10 +130,10 @@ class Board:
         return filtered_tiles
 
     def check_adjacency(self, start, end, shipping_limit) -> AdjacencyType:
-        end = self.get(end)
-        if end in self.get_directly_adj(start):
+        end_tile = self.get(end)
+        if end_tile in self.get_directly_adj(start):
             return AdjacencyType.DIRECT
-        if end in self.get_indirectly_adj(self.get(start), shipping_limit):
+        if end_tile in self.get_indirectly_adj(self.get(start), shipping_limit):
             return AdjacencyType.INDIRECT
         return None
 

--- a/src/Board.py
+++ b/src/Board.py
@@ -108,7 +108,7 @@ class Board:
             )  # bottom right
         if start[0] > 0:
             adjacent_tile_set.add(self.get((start[0] - 1, start[1])))  # left
-        return adjacent_tile_set  # = [TL,TR,R,BR,BL,L]
+        return adjacent_tile_set
 
     def get_indirectly_adj(self, tile=None, shipping_limit=0) -> set:
         tiles = tile.adjacency

--- a/src/Board.py
+++ b/src/Board.py
@@ -61,10 +61,11 @@ class Board:
 
     def calculate_adjacency_for_tiles(self):
         for row in range(len(self.data)):
-            for tile in range(len(self.data[row])):
-                coords = (tile, row)
-                if self.get(coords).terrain != Terrain.EMPTY:
-                    self.get(coords).adjacency = set(self.get_directly_adj(coords))
+            for col in range(len(self.data[row])):
+                coords = (col, row)
+                tile = self.get(coords)
+                if tile.terrain != Terrain.EMPTY:
+                    tile.adjacency = set(self.get_directly_adj(coords))
 
     def get_tiles_of_type(self, terrain_filter: Terrain):
         return_list = []

--- a/src/Board.py
+++ b/src/Board.py
@@ -85,7 +85,7 @@ class Board:
     def get_directly_adj(
         self,
         start: Coords = (0, 0),
-    ) -> set:
+    ) -> Set[Tile]:
         adjacent_tile_list = []
         row_start_offset = -((start[1] + 1) % 2)
         if start[1] > 0:

--- a/src/Board.py
+++ b/src/Board.py
@@ -58,6 +58,12 @@ class Board:
         else:
             raise ValueError("Unrecognised map style")
 
+    def calculate_adjacency_for_tiles(self):
+        for row in range(len(self.data)):
+            for tile in range(len(row)):
+                coords = (row, tile)
+                self.get(coords).adjacency = self.get_directly_adj(coords)
+
     def get_tiles_of_type(self, terrain_filter: Terrain):
         return_list = []
         for row in range(0, len(self.data)):
@@ -111,6 +117,14 @@ class Board:
     def get_indirectly_adj(
         self, start=(0, 0), terrain_filter=None, shipping_limit=0
     ) -> list:
+        tiles = tile.adjacency
+        if shipping_limit <= 0:
+            return tiles
+        all_tiles = set(tiles)
+        for next_tile in tiles:
+            all_tiles |= next_tile.adjacent
+        return all_tiles
+
         unfiltered_list = []
         if self.get_directly_adj(start, Terrain.RIVER) == []:
             return self.get_directly_adj(start, terrain_filter)

--- a/src/Board.py
+++ b/src/Board.py
@@ -84,7 +84,7 @@ class Board:
     def get_directly_adj(
         self,
         start: Coords = (0, 0),
-    ) -> List[Coords]:
+    ) -> set:
         adjacent_tile_list = []
         row_start_offset = -((start[1] + 1) % 2)
         if start[1] > 0:
@@ -109,9 +109,7 @@ class Board:
             adjacent_tile_list.append(self.get((start[0] - 1, start[1])))  # left
         return adjacent_tile_list  # = [TL,TR,R,BR,BL,L]
 
-    def get_indirectly_adj(
-        self, tile=None, shipping_limit=0
-    ) -> list:
+    def get_indirectly_adj(self, tile=None, shipping_limit=0) -> set:
         tiles = tile.adjacency
         if shipping_limit <= 0:
             return tiles
@@ -122,33 +120,13 @@ class Board:
                     t, shipping_limit=shipping_limit - 1
                 )
         return all_tiles
-        # Commented out because I'm not confident that the
-        # replacement code for get_indirectly_adjacent will work.
-        #
-        # unfiltered_list = []
-        # if self.get_directly_adj(start, Terrain.RIVER) == []:
-        #     return self.get_directly_adj(start, terrain_filter)
-        # if shipping_limit == 0:
-        #     unfiltered_list = self.get_directly_adj(start)
-        # else:
-        #     direct_list = self.get_directly_adj(start, None)
-        #     for tile in direct_list:
-        #         if tile not in unfiltered_list:
-        #             unfiltered_list.append(tile)
-        #         if self.get(tile).terrain == Terrain.RIVER:
-        #             indirect_list = self.get_indirectly_adj(
-        #                 tile, None, shipping_limit - 1
-        #             )
-        #             for t in indirect_list:
-        #                 if t not in unfiltered_list and t != start:
-        #                     unfiltered_list.append(t)
-        # if terrain_filter is None:
-        #     return unfiltered_list
-        # adjacent_tile_list = []
-        # for tile in unfiltered_list:
-        #     if self.get(tile)._terrain == terrain_filter:
-        #         adjacent_tile_list.append(tile)
-        # return adjacent_tile_list
+
+    def filter_terrain(self, tiles, terrain_filter=None) -> set:
+        filtered_tiles = set()
+        for tile in tiles:
+            if tile.terrain == terrain_filter:
+                filtered_tiles.add(tile)
+        return filtered_tiles
 
     def check_adjacency(self, start, end, shipping_limit) -> AdjacencyType:
         end = self.get(end)

--- a/src/Board.py
+++ b/src/Board.py
@@ -86,40 +86,41 @@ class Board:
         self,
         start: Coords = (0, 0),
     ) -> Set[Tile]:
-        adjacent_tile_list = []
+        adjacent_tile_set = set()
         row_start_offset = -((start[1] + 1) % 2)
         if start[1] > 0:
-            adjacent_tile_list.append(
+            adjacent_tile_set.add(
                 self.get((start[0] + row_start_offset, start[1] - 1))
             )  # top left
-            adjacent_tile_list.append(
+            adjacent_tile_set.add(
                 self.get((start[0] + row_start_offset + 1, start[1] - 1))
             )  # top right
         if start[0] < BOARD_WIDTH - 2 or (
             start[1] % 2 == 1 and start[0] < BOARD_WIDTH - 1
         ):
-            adjacent_tile_list.append(self.get((start[0] + 1, start[1])))  # right
+            adjacent_tile_set.add(self.get((start[0] + 1, start[1])))  # right
         if start[1] < BOARD_HEIGHT - 1:
-            adjacent_tile_list.append(
+            adjacent_tile_set.add(
                 self.get((start[0] + row_start_offset + 1, start[1] + 1))
             )  # bottom left
-            adjacent_tile_list.append(
+            adjacent_tile_set.add(
                 self.get((start[0] + row_start_offset, start[1] + 1))
             )  # bottom right
         if start[0] > 0:
-            adjacent_tile_list.append(self.get((start[0] - 1, start[1])))  # left
-        return adjacent_tile_list  # = [TL,TR,R,BR,BL,L]
+            adjacent_tile_set.add(self.get((start[0] - 1, start[1])))  # left
+        return adjacent_tile_set  # = [TL,TR,R,BR,BL,L]
 
     def get_indirectly_adj(self, tile=None, shipping_limit=0) -> set:
         tiles = tile.adjacency
         if shipping_limit <= 0:
             return tiles
-        all_tiles = set()
+        all_tiles = set(tiles)
         for t in tiles:
             if t.terrain == Terrain.RIVER:
                 all_tiles |= self.get_indirectly_adj(
                     t, shipping_limit=shipping_limit - 1
                 )
+        all_tiles.remove(tile)
         return all_tiles
 
     def filter_terrain(self, tiles: Set[Tile], terrain_filter=None) -> set:

--- a/src/Board_test.py
+++ b/src/Board_test.py
@@ -50,7 +50,6 @@ class TestBoard:
         assert aMap.get_indirectly_adj(tile=aMap.get((1, 4))) == aMap.get_directly_adj(
             start=(1, 4)
         )
-        print(str(aMap.get((2, 3))))
         assert aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1) == {
             aMap.get((2, 2)),
             aMap.get((3, 2)),

--- a/src/Board_test.py
+++ b/src/Board_test.py
@@ -16,14 +16,14 @@ class TestBoard:
         assert aMap.get((6, 3))._terrain == Terrain.LAKE
         assert aMap.get((7, 7))._terrain == Terrain.SWAMP
 
-        assert aMap.get_directly_adj(start=(2, 3)) == [
+        assert aMap.get_directly_adj(start=(2, 3)) == {
             aMap.get((2, 2)),
             aMap.get((3, 2)),
             aMap.get((3, 3)),
             aMap.get((3, 4)),
             aMap.get((2, 4)),
             aMap.get((1, 3)),
-        ]
+        }
         my_set = set()
         assert (
             aMap.filter_terrain(
@@ -31,88 +31,70 @@ class TestBoard:
             )
             == my_set
         )
-        my_set.add(aMap.get((2, 2)))
-        assert (
-            aMap.filter_terrain(
-                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.SWAMP
-            )
-            == my_set
-        )
-        my_set = set()
-        my_set.add(aMap.get((3, 4)))
-        my_set.add(aMap.get((1, 3)))
-        assert (
-            aMap.filter_terrain(
-                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.LAKE
-            )
-            == my_set
-        )
-        my_set = set()
-        my_set.add(aMap.get((2, 4)))
-        assert (
-            aMap.filter_terrain(
-                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.WASTELAND
-            )
-            == my_set
-        )
-        my_set = set()
-        my_set.add(aMap.get((3, 2)))
-        my_set.add(aMap.get((3, 3)))
-        assert (
-            aMap.filter_terrain(
-                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.RIVER
-            )
-            == my_set
-        )
+        assert aMap.filter_terrain(
+            aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.SWAMP
+        ) == {aMap.get((2, 2))}
+        assert aMap.filter_terrain(
+            aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.LAKE
+        ) == {aMap.get((3, 4)), aMap.get((1, 3))}
+        assert aMap.filter_terrain(
+            aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.WASTELAND
+        ) == {aMap.get((2, 4))}
+        assert aMap.filter_terrain(
+            aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.RIVER
+        ) == {aMap.get((3, 2)), aMap.get((3, 3))}
 
         assert aMap.check_adjacency((6, 3), (4, 3), 0) is None
         assert aMap.check_adjacency((6, 3), (5, 3), 0) == AdjacencyType.DIRECT
 
-        # The board.get_indirectly_adj() function returns a set without a specific order for the items.
-        # I don't know how to write a test that doesn't care about the order of the Items.
-        # The function still works, you can tell because the board.check_adjacency() function also works.
-        # However I would still like to get these tests working again.
-        #
-        # assert aMap.get_indirectly_adj(tile=aMap.get((1, 4))) == aMap.get_directly_adj(
-        #     start=(1, 4)
-        # )
-        # assert aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1) == [
-        #     aMap.get((2, 2)),
-        #     aMap.get((3, 2)),
-        #     aMap.get((2, 1)),
-        #     aMap.get((3, 1)),
-        #     aMap.get((4, 2)),
-        #     aMap.get((3, 3)),
-        #     aMap.get((4, 3)),
-        #     aMap.get((4, 4)),
-        #     aMap.get((3, 4)),
-        #     aMap.get((2, 4)),
-        #     aMap.get((1, 3)),
-        # ]
-        # assert (
-        #     aMap.get_indirectly_adj(
-        #         tile=aMap.get((2, 3)), terrain_filter=Terrain.DESERT
-        #     )
-        #     == []
-        # )
-        # assert aMap.get_indirectly_adj(
-        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.SWAMP, shipping_limit=1
-        # ) == [aMap.get((2, 2)), aMap.get((4, 4))]
-        # assert aMap.get_indirectly_adj(
-        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.LAKE, shipping_limit=1
-        # ) == [aMap.get((3, 4)), aMap.get((1, 3))]
-        # assert aMap.get_indirectly_adj(
-        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.WASTELAND, shipping_limit=1
-        # ) == [aMap.get((2, 4))]
-        # assert aMap.get_indirectly_adj(
-        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.RIVER, shipping_limit=1
-        # ) == [aMap.get((3, 2)), aMap.get((2, 1)), aMap.get((3, 3)), aMap.get((4, 3))]
-        # assert aMap.get_indirectly_adj(
-        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.FIELD, shipping_limit=1
-        # ) == [aMap.get((3, 1))]
-        # assert aMap.get_indirectly_adj(
-        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.MOUNTAIN, shipping_limit=1
-        # ) == [aMap.get((4, 2))]
+        assert aMap.get_indirectly_adj(tile=aMap.get((1, 4))) == aMap.get_directly_adj(
+            start=(1, 4)
+        )
+        print(str(aMap.get((2, 3))))
+        assert aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1) == {
+            aMap.get((2, 2)),
+            aMap.get((3, 2)),
+            aMap.get((2, 1)),
+            aMap.get((3, 1)),
+            aMap.get((4, 2)),
+            aMap.get((3, 3)),
+            aMap.get((4, 3)),
+            aMap.get((4, 4)),
+            aMap.get((3, 4)),
+            aMap.get((2, 4)),
+            aMap.get((1, 3)),
+        }
+        assert (
+            aMap.filter_terrain(
+                aMap.get_indirectly_adj(tile=aMap.get((2, 3))),
+                terrain_filter=Terrain.DESERT,
+            )
+            == my_set
+        )
+        assert aMap.filter_terrain(
+            aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1),
+            terrain_filter=Terrain.SWAMP,
+        ) == {aMap.get((2, 2)), aMap.get((4, 4))}
+        assert aMap.filter_terrain(
+            aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1),
+            terrain_filter=Terrain.LAKE,
+        ) == {aMap.get((3, 4)), aMap.get((1, 3))}
+        assert aMap.filter_terrain(
+            aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1),
+            terrain_filter=Terrain.WASTELAND,
+        ) == {aMap.get((2, 4))}
+        assert aMap.filter_terrain(
+            aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1),
+            terrain_filter=Terrain.RIVER,
+        ) == {aMap.get((3, 2)), aMap.get((2, 1)), aMap.get((3, 3)), aMap.get((4, 3))}
+        assert aMap.filter_terrain(
+            aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1),
+            terrain_filter=Terrain.FIELD,
+        ) == {aMap.get((3, 1))}
+        assert aMap.filter_terrain(
+            aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1),
+            terrain_filter=Terrain.MOUNTAIN,
+        ) == {aMap.get((4, 2))}
 
         assert aMap.check_adjacency((7, 7), (9, 6), 0) == None
         assert aMap.check_adjacency((7, 7), (9, 6), 1) == AdjacencyType.INDIRECT

--- a/src/Board_test.py
+++ b/src/Board_test.py
@@ -17,69 +17,57 @@ class TestBoard:
         assert aMap.get((7, 7))._terrain == Terrain.SWAMP
 
         assert aMap.get_directly_adj(start=(2, 3)) == [
-            (2, 2),
-            (3, 2),
-            (3, 3),
-            (3, 4),
-            (2, 4),
-            (1, 3),
-        ]
-        assert aMap.get_directly_adj(start=(2, 3), terrain_filter=Terrain.DESERT) == []
-        assert aMap.get_directly_adj(start=(2, 3), terrain_filter=Terrain.SWAMP) == [
-            (2, 2)
-        ]
-        assert aMap.get_directly_adj(start=(2, 3), terrain_filter=Terrain.LAKE) == [
-            (3, 4),
-            (1, 3),
-        ]
-        assert aMap.get_directly_adj(
-            start=(2, 3), terrain_filter=Terrain.WASTELAND
-        ) == [(2, 4)]
-        assert aMap.get_directly_adj(start=(2, 3), terrain_filter=Terrain.RIVER) == [
-            (3, 2),
-            (3, 3),
+            aMap.get((2, 2)),
+            aMap.get((3, 2)),
+            aMap.get((3, 3)),
+            aMap.get((3, 4)),
+            aMap.get((2, 4)),
+            aMap.get((1, 3)),
         ]
 
         assert aMap.check_adjacency((6, 3), (4, 3), 0) is None
         assert aMap.check_adjacency((6, 3), (5, 3), 0) == AdjacencyType.DIRECT
 
-        assert aMap.get_indirectly_adj(start=(1, 4)) == aMap.get_directly_adj(
-            start=(1, 4)
-        )
-        assert aMap.get_indirectly_adj(start=(2, 3), shipping_limit=1) == [
-            (2, 2),
-            (3, 2),
-            (2, 1),
-            (3, 1),
-            (4, 2),
-            (3, 3),
-            (4, 3),
-            (4, 4),
-            (3, 4),
-            (2, 4),
-            (1, 3),
-        ]
-        assert (
-            aMap.get_indirectly_adj(start=(2, 3), terrain_filter=Terrain.DESERT) == []
-        )
-        assert aMap.get_indirectly_adj(
-            start=(2, 3), terrain_filter=Terrain.SWAMP, shipping_limit=1
-        ) == [(2, 2), (4, 4)]
-        assert aMap.get_indirectly_adj(
-            start=(2, 3), terrain_filter=Terrain.LAKE, shipping_limit=1
-        ) == [(3, 4), (1, 3)]
-        assert aMap.get_indirectly_adj(
-            start=(2, 3), terrain_filter=Terrain.WASTELAND, shipping_limit=1
-        ) == [(2, 4)]
-        assert aMap.get_indirectly_adj(
-            start=(2, 3), terrain_filter=Terrain.RIVER, shipping_limit=1
-        ) == [(3, 2), (2, 1), (3, 3), (4, 3)]
-        assert aMap.get_indirectly_adj(
-            start=(2, 3), terrain_filter=Terrain.FIELD, shipping_limit=1
-        ) == [(3, 1)]
-        assert aMap.get_indirectly_adj(
-            start=(2, 3), terrain_filter=Terrain.MOUNTAIN, shipping_limit=1
-        ) == [(4, 2)]
+        # assert aMap.get_indirectly_adj(tile=aMap.get((1, 4))) == aMap.get_directly_adj(
+        #     start=(1, 4)
+        # )
+        # assert aMap.get_indirectly_adj(tile=aMap.get((2, 3)), shipping_limit=1) == [
+        #     aMap.get((2, 2)),
+        #     aMap.get((3, 2)),
+        #     aMap.get((2, 1)),
+        #     aMap.get((3, 1)),
+        #     aMap.get((4, 2)),
+        #     aMap.get((3, 3)),
+        #     aMap.get((4, 3)),
+        #     aMap.get((4, 4)),
+        #     aMap.get((3, 4)),
+        #     aMap.get((2, 4)),
+        #     aMap.get((1, 3)),
+        # ]
+        # assert (
+        #     aMap.get_indirectly_adj(
+        #         tile=aMap.get((2, 3)), terrain_filter=Terrain.DESERT
+        #     )
+        #     == []
+        # )
+        # assert aMap.get_indirectly_adj(
+        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.SWAMP, shipping_limit=1
+        # ) == [aMap.get((2, 2)), aMap.get((4, 4))]
+        # assert aMap.get_indirectly_adj(
+        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.LAKE, shipping_limit=1
+        # ) == [aMap.get((3, 4)), aMap.get((1, 3))]
+        # assert aMap.get_indirectly_adj(
+        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.WASTELAND, shipping_limit=1
+        # ) == [aMap.get((2, 4))]
+        # assert aMap.get_indirectly_adj(
+        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.RIVER, shipping_limit=1
+        # ) == [aMap.get((3, 2)), aMap.get((2, 1)), aMap.get((3, 3)), aMap.get((4, 3))]
+        # assert aMap.get_indirectly_adj(
+        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.FIELD, shipping_limit=1
+        # ) == [aMap.get((3, 1))]
+        # assert aMap.get_indirectly_adj(
+        #     tile=aMap.get((2, 3)), terrain_filter=Terrain.MOUNTAIN, shipping_limit=1
+        # ) == [aMap.get((4, 2))]
 
         assert aMap.check_adjacency((7, 7), (9, 6), 0) == None
         assert aMap.check_adjacency((7, 7), (9, 6), 1) == AdjacencyType.INDIRECT

--- a/src/Board_test.py
+++ b/src/Board_test.py
@@ -24,10 +24,55 @@ class TestBoard:
             aMap.get((2, 4)),
             aMap.get((1, 3)),
         ]
+        my_set = set()
+        assert (
+            aMap.filter_terrain(
+                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.DESERT
+            )
+            == my_set
+        )
+        my_set.add(aMap.get((2, 2)))
+        assert (
+            aMap.filter_terrain(
+                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.SWAMP
+            )
+            == my_set
+        )
+        my_set = set()
+        my_set.add(aMap.get((3, 4)))
+        my_set.add(aMap.get((1, 3)))
+        assert (
+            aMap.filter_terrain(
+                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.LAKE
+            )
+            == my_set
+        )
+        my_set = set()
+        my_set.add(aMap.get((2, 4)))
+        assert (
+            aMap.filter_terrain(
+                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.WASTELAND
+            )
+            == my_set
+        )
+        my_set = set()
+        my_set.add(aMap.get((3, 2)))
+        my_set.add(aMap.get((3, 3)))
+        assert (
+            aMap.filter_terrain(
+                aMap.get_directly_adj(start=(2, 3)), terrain_filter=Terrain.RIVER
+            )
+            == my_set
+        )
 
         assert aMap.check_adjacency((6, 3), (4, 3), 0) is None
         assert aMap.check_adjacency((6, 3), (5, 3), 0) == AdjacencyType.DIRECT
 
+        # The board.get_indirectly_adj() function returns a set without a specific order for the items.
+        # I don't know how to write a test that doesn't care about the order of the Items.
+        # The function still works, you can tell because the board.check_adjacency() function also works.
+        # However I would still like to get these tests working again.
+        #
         # assert aMap.get_indirectly_adj(tile=aMap.get((1, 4))) == aMap.get_directly_adj(
         #     start=(1, 4)
         # )

--- a/src/Tile.py
+++ b/src/Tile.py
@@ -16,6 +16,7 @@ class Tile:
         self._terrain = terrain
         self._building = None
         self._faction = None
+        self._adjacency = None
 
     @property
     def terrain(self) -> Terrain:
@@ -27,7 +28,7 @@ class Tile:
 
     @property
     def adjacency(self) -> "Set[Tile]":
-        if self._adjacency == None:
+        if self._adjacency is None:
             raise InvalidActionError(
                 "Cannot check for a tile's adjacency while the game is still being set up"
             )

--- a/src/Tile.py
+++ b/src/Tile.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Set, Type
 from Building import Building
 from Faction import Faction
 from Terrain import Terrain
@@ -10,6 +10,7 @@ class Tile:
     _terrain: Terrain
     _building: Building | None
     _faction: Type[Faction] | None
+    _adjacency: "Set[Tile] | None"
 
     def __init__(self, terrain: Terrain) -> None:
         self._terrain = terrain
@@ -23,6 +24,18 @@ class Tile:
     @property
     def building(self) -> Building | None:
         return self._building
+
+    @property
+    def adjacency(self) -> "Set[Tile]":
+        if self._adjacency == None:
+            raise InvalidActionError(
+                "Cannot check for a tile's adjacency while the game is still being set up"
+            )
+        return self._adjacency
+
+    @adjacency.setter
+    def adjacency(self, tiles: "Set[Tile]") -> None:
+        self._adjacency = tiles
 
     def terraform(self, terrain_goal: Terrain) -> None:
         if self._building or self._faction:


### PR DESCRIPTION
The tests that are specifically for the get_indirectly_adj() function cave been commented out because they are testing for a specific order of the items in the output of the function. but the function isn't fussed about the order being anything specific. it still works because all the tests for the check_adjacency() function pass, and it calls the get_indirectly_adj() function.

But I would like to have the unit tests working.